### PR TITLE
installing parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Only wget and cdo are needed. These can be easily installed with:
 sudo apt-get install wget
 sudo apt-get install cdo
 ```
+To process multiple files efficiently, install `parallel`
+```
+sudo apt install parallel
+```
 
 For aggregating netCDF files into ncml files (optional), it is necessary to have a conda environment with R and climate4R packages installed. This can be done easily with:
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ sudo apt-get install cdo
 ```
 To process multiple files efficiently, install `parallel`
 ```
+sudo apt update
 sudo apt install parallel
 ```
 


### PR DESCRIPTION
I first ran the script and got into this error

isimip.sh: line 247: parallel: command not found

To process multiple files efficiently, one needs to install `parallel` but this is not explicitly mentioned in the instructions
```
sudo apt update
sudo apt install parallel
```